### PR TITLE
Fixed issue with XML parsing

### DIFF
--- a/Splunk_for_Sharepoint/default/data/ui/views/usage_sites.xml
+++ b/Splunk_for_Sharepoint/default/data/ui/views/usage_sites.xml
@@ -36,7 +36,7 @@ eventtype=mssharepoint-audit ItemType=1 Event=3
 | inputlookup SPSite
 | table Id,Url
 | rename Id as SiteId
-| join type=outer [ search eventtype=mssharepoint-audit Event<14 | stats count by SiteId ]
+| join type=outer [ search eventtype=mssharepoint-audit Event&lt;14 | stats count by SiteId ]
 | where isnull(count)
 | table SiteId,Url
    ]]></searchString>
@@ -49,7 +49,7 @@ eventtype=mssharepoint-audit ItemType=1 Event=3
   <table>
    <title>Read-Only Sites (No Uploads in Last 7 days)</title>
    <searchString><![CDATA[
-eventtype=mssharepoint-audit Event<14
+eventtype=mssharepoint-audit Event&lt;14
 | eval T=if(Event==1 OR Event==3,"read","write")
 | chart count by SiteId,T
 | where write==0 AND read>0


### PR DESCRIPTION
The `<` character in searchString tags was breaking the XML parsing, thus forbidding Splunk restarts and leading to broken pages.

What was happening was that the `<14` part of the file was considered as an opening tag from an XML pov (Editing the XML with GUI or in a TextEditor showed the problem directly).

This updates the character to be the entity one, which is fixing searches, and related panels.
